### PR TITLE
Fix some react warnings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -95,7 +95,7 @@ class App extends Component {
             <Sider theme="dark" width={250}>
               <Content style={{ padding: '10px'}} >
                 <Row gutter={8}><Col span={24} ><img src="/ss_logo.png" width={40} style={{padding: '5px', float: 'left',
-                'vertical-align': 'middle'}}/><h2 style={{color: 'rgba(255, 255, 255, 0.67)', 'margin-top': '8px'}}>SharedStreets</h2></Col></Row>
+                verticalAlign: 'middle'}}/><h2 style={{color: 'rgba(255, 255, 255, 0.67)', marginTop: '8px'}}>SharedStreets</h2></Col></Row>
               </Content>
               <Menu
                 mode="inline"


### PR DESCRIPTION
React expects [style objects with camel case keys](https://reactjs.org/docs/dom-elements.html#style).

<img width="844" alt="screen shot 2018-02-08 at 2 45 57 pm" src="https://user-images.githubusercontent.com/875591/36002543-67c07f50-0cdf-11e8-9615-986f82a7529a.png">
